### PR TITLE
[ audio ] add initial audio recording and play back for joystick

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,9 +10,18 @@
 
 import React from 'react';
 import Joystick from './components/Joystick/Joystick';
-import {Alert, StyleSheet, View} from 'react-native';
+import {Alert, Text, StyleSheet, View} from 'react-native';
 
-import AudioRecorderPlayer from 'react-native-audio-recorder-player';
+import AudioRecorderPlayer, {
+  AVEncoderAudioQualityIOSType,
+  AVEncodingOption,
+  AudioEncoderAndroidType,
+  AudioSet,
+  AudioSourceAndroidType,
+  PlayBackType,
+  RecordBackType,
+} from 'react-native-audio-recorder-player';
+
 import {
   SwipeClassification,
   SwipeHandlersType,
@@ -22,6 +31,13 @@ interface Props {}
 
 interface State {
   isRecording: boolean;
+  isPlaying: boolean;
+  recordSecs: number;
+  recordTime: string;
+  currentPositionSec: number;
+  currentDurationSec: number;
+  playTime: string;
+  duration: string;
 }
 
 class App extends React.Component<Props, State> {
@@ -29,29 +45,134 @@ class App extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    this.state = {isRecording: false};
+    this.state = {
+      isRecording: false,
+      isPlaying: false,
+      recordSecs: 0,
+      recordTime: '00:00:00',
+      currentPositionSec: 0,
+      currentDurationSec: 0,
+      playTime: '00:00:00',
+      duration: '00:00:00',
+    };
     this.audioRecorderPlayer = new AudioRecorderPlayer();
   }
 
-  private startRecording = () => {
-    console.log('starting!');
+  private startRecording = async () => {
+    console.log('start recording!');
+
+    const audioSet: AudioSet = {
+      AudioEncoderAndroid: AudioEncoderAndroidType.AAC,
+      AudioSourceAndroid: AudioSourceAndroidType.MIC,
+      AVEncoderAudioQualityKeyIOS: AVEncoderAudioQualityIOSType.high,
+      AVNumberOfChannelsKeyIOS: 2,
+      AVFormatIDKeyIOS: AVEncodingOption.aac,
+    };
+
+    this.audioRecorderPlayer.addRecordBackListener((e: RecordBackType) => {
+      this.setState({
+        recordSecs: e.currentPosition,
+        recordTime: this.audioRecorderPlayer.mmssss(
+          Math.floor(e.currentPosition),
+        ),
+      });
+    });
+
+    const uri = await this.audioRecorderPlayer.startRecorder(
+      undefined,
+      audioSet,
+      true,
+    );
+
+    console.log(uri);
   };
 
-  private stopRecording = () => {
-    console.log('stopping!');
+  private stopRecording = async () => {
+    console.log('stop recording!');
+
+    const result = await this.audioRecorderPlayer.stopRecorder();
+    this.audioRecorderPlayer.removeRecordBackListener();
+
+    console.log(result);
   };
 
-  private toggleRecording = () => {
+  private onPauseRecord = async () => {
+    try {
+      const r = await this.audioRecorderPlayer.pauseRecorder();
+      console.log(r);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  private onResumeRecord = async () => {
+    await this.audioRecorderPlayer.resumeRecorder();
+  };
+
+  private toggleRecording = async () => {
     this.state.isRecording ? this.stopRecording() : this.startRecording();
     this.setState(previous => {
       return {isRecording: !previous.isRecording};
     });
   };
 
+  private startPlaying = async () => {
+    console.log('start playing!');
+
+    this.audioRecorderPlayer.addPlayBackListener((e: PlayBackType) => {
+      this.setState({
+        currentPositionSec: e.currentPosition,
+        currentDurationSec: e.duration,
+        playTime: this.audioRecorderPlayer.mmssss(
+          Math.floor(e.currentPosition),
+        ),
+        duration: this.audioRecorderPlayer.mmssss(Math.floor(e.duration)),
+      });
+
+      if (e.currentPosition === e.duration) {
+        this.togglePlaying();
+      }
+    });
+
+    const msg = await this.audioRecorderPlayer.startPlayer();
+    const volume = await this.audioRecorderPlayer.setVolume(1.0);
+
+    console.log(msg, volume);
+  };
+
+  private stopPlaying = async () => {
+    console.log('stop playing!');
+
+    this.audioRecorderPlayer.stopPlayer();
+    this.audioRecorderPlayer.removePlayBackListener();
+  };
+
+  private onPausePlay = async () => {
+    await this.audioRecorderPlayer.pausePlayer();
+  };
+
+  private onResumePlay = async () => {
+    await this.audioRecorderPlayer.resumePlayer();
+  };
+
+  private togglePlaying = async () => {
+    this.state.isPlaying ? this.stopPlaying() : this.startPlaying();
+    this.setState(previous => {
+      return {isPlaying: !previous.isPlaying};
+    });
+  };
+
   private defaultSwipeHandlerBuilder = (direction: string) => {
-    return () => {
-      Alert.alert(`yay a ${direction} swipe has been handled`);
-    };
+    switch (direction) {
+      case 'up':
+        return () => this.togglePlaying();
+      case 'down':
+        return () => this.toggleRecording();
+      default:
+        return () => {
+          Alert.alert(`${direction} swipe!`);
+        };
+    }
   };
 
   private swipeHandlers: SwipeHandlersType = {
@@ -66,6 +187,13 @@ class App extends React.Component<Props, State> {
   render() {
     return (
       <View style={styles.container}>
+        {/* TODO: remove this! just wanted to visually communicate changes */}
+        <Text style={styles.text}>
+          {'isRecording:  ' + this.state.isRecording + '\n'}
+          {'recordTime:  ' + this.state.recordTime + '\n'}
+          {'isPlaying:      ' + this.state.isPlaying + '\n'}
+          {'playTime:      ' + this.state.playTime + '\n'}
+        </Text>
         <Joystick onButtonPress={() => {}} swipeHandlers={this.swipeHandlers} />
       </View>
     );
@@ -78,6 +206,9 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  text: {
+    fontFamily: 'Cochin',
   },
 });
 

--- a/App.tsx
+++ b/App.tsx
@@ -128,10 +128,6 @@ class App extends React.Component<Props, State> {
         ),
         duration: this.audioRecorderPlayer.mmssss(Math.floor(e.duration)),
       });
-
-      if (e.currentPosition === e.duration) {
-        this.togglePlaying();
-      }
     });
 
     const msg = await this.audioRecorderPlayer.startPlayer();

--- a/components/Joystick/JoystickHelper.tsx
+++ b/components/Joystick/JoystickHelper.tsx
@@ -26,12 +26,10 @@ export class JoystickHelper {
     this.height = height;
     this.xForgiveness = this.width * JoystickHelper.X_FORGIVENESS_RATIO;
     this.yForgiveness = this.height * JoystickHelper.Y_FORGIVENESS_RATIO;
-    console.log(this.xForgiveness, this.yForgiveness);
     this.xDisplacementThreshold =
       this.width * JoystickHelper.X_DISPLACEMENT_THRESHOLD_RATIO;
     this.yDisplacementThreshold =
       this.height * JoystickHelper.Y_DISPLACEMENT_THRESHOLD_RATIO;
-    console.log(this.xDisplacementThreshold, this.yDisplacementThreshold);
   }
 
   classify(x: number, y: number): SwipeClassification {

--- a/ios/yucky.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/yucky.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/yucky/Info.plist
+++ b/ios/yucky/Info.plist
@@ -37,6 +37,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Give $(PRODUCT_NAME) permission to use your microphone. Your record wont be shared without your permission.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
## context
- obviously we need to record and playback

## this diff my nigga
- adds `react-native-audio-recorder-player` to the project
- updates `Info.plist` to ask for microphone permissions on iOS
- scaffolds `start`, `stop`, `pause`, `resume` for recording and playing back audio
- swipe down on joystick => toggles recording
- swipe up on joystick => toggles playback
- added some cheap text element to be deleted so that functionality was visible

## follow-up
- #2 
- #1 

sorry about the issue numbers... i made them out of order.

## proof u lil bitch
- check ur imessage for the video (files are too large to put on github or discord)